### PR TITLE
Update comic-storyline-delete.php

### DIFF
--- a/comiccontrol/parts/comic-storyline-delete.php
+++ b/comiccontrol/parts/comic-storyline-delete.php
@@ -1,87 +1,173 @@
-<?php //comic-storyline-delete.php - handles deleting existing storylines ?>
-
-<?php
-
-//create and output quick links
-$links = array(
-	array(
-		'link' => $ccurl . $navslug . '/' . $ccpage->module->slug,
-		'text' => str_replace('%s',$ccpage->title,$lang['Return to managing %s'])
-	),
-	array(
-		'link' => $ccurl . $navslug.'/'.$ccpage->module->slug."/manage-posts",
-		'text' => $lang['Edit a different storyline']
-	),
-	array(
-		'link' => $ccurl . $navslug.'/'.$ccpage->module->slug."/add-storyline",
-		'text' => $lang['Add another storyline']
-	)
-);
-quickLinks($links);
-
-?>
-
-<main id="content">
-
-<?php //get selected page 
-$storylineid = getSlug(4);
-$query = "SELECT * FROM cc_" . $tableprefix . "comics_storyline WHERE id=:id LIMIT 1";
-$stmt = $cc->prepare($query);
-$stmt->execute(['id' => $storylineid]);
-$thisstoryline = $stmt->fetch();
-
-//show error message if there was no storyline found
-if(empty($thisstoryline)){
-	echo '<div class="msg error f-c">' . $lang['No storyline was found with this information.'] . '</div>';
-}
-else{
-	
-	//delete the storyline if confirmed
-	if(getSlug(5) == "confirmed"){
-	
-		$stmt = $cc->prepare("SELECT * FROM cc_" . $tableprefix . "comics_storyline WHERE parent=:parent");
-		$stmt->execute(['parent' => $thisstoryline['id']]);
-		$children = $stmt->fetchAll();
-		
-		//move the children up a level
-		foreach($children as $child){
-			$stmt = $cc->prepare("UPDATE cc_" . $tableprefix . "comics_storyline SET parent=:parent WHERE id=:id");
-			$stmt->execute(['parent' => $thisstoryline['parent'], 'level' => $thisstoryline['level'], 'id' => $child['id']]);
-		}
-		
-		$stmt = $cc->prepare("DELETE FROM cc_" . $tableprefix . "comics_storyline WHERE id=:id");
-		$stmt->execute(['id' => $thisstoryline['id']]);
-		
-		//give success message
-		?>
-		<div class="msg success f-c"><?=str_replace("%s",$thisstoryline['name'],$lang['%s has been deleted.'])?></div>
-		
-		<?php
-		
-		
-	}else{
-	
-		//prompt user to delete page ?>
-
-		<div class="msg prompt f-c"><?=str_replace("%s",$thisstoryline['name'],$lang['Are you sure you want to delete %s? This action cannot be undone.'])?> <?=$lang['Sub-storylines will be moved up to this storyline\'s level.']?></div>
-		<?php
-
-		echo '<div class="cc-btn-row">';
-		buildButton(
-			"light-bg",
-			$ccurl . $navslug.'/'.$ccpage->module->slug.'/delete-storyline/' . $thisstoryline['id'] . '/confirmed',
-			$lang['Yes']
-		);
-		buildButton(
-			"dark-bg",
-			$ccurl . $navslug.'/'.$ccpage->module->slug."/manage-posts",
-			$lang['No']
-		);
-		echo '</div>';
-		
-	}
-
-}
-?>
-
+<?php //comic-storyline-delete.php - handles deleting existing storylines ?>
+
+
+
+<?php
+
+
+
+//create and output quick links
+
+$links = array(
+
+	array(
+
+		'link' => $ccurl . $navslug . '/' . $ccpage->module->slug,
+
+		'text' => str_replace('%s',$ccpage->title,$lang['Return to managing %s'])
+
+	),
+
+	array(
+
+		'link' => $ccurl . $navslug.'/'.$ccpage->module->slug."/manage-posts",
+
+		'text' => $lang['Edit a different storyline']
+
+	),
+
+	array(
+
+		'link' => $ccurl . $navslug.'/'.$ccpage->module->slug."/add-storyline",
+
+		'text' => $lang['Add another storyline']
+
+	)
+
+);
+
+quickLinks($links);
+
+
+
+?>
+
+
+
+<main id="content">
+
+
+
+<?php //get selected page 
+
+$storylineid = getSlug(4);
+
+$query = "SELECT * FROM cc_" . $tableprefix . "comics_storyline WHERE id=:id LIMIT 1";
+
+$stmt = $cc->prepare($query);
+
+$stmt->execute(['id' => $storylineid]);
+
+$thisstoryline = $stmt->fetch();
+
+
+
+//show error message if there was no storyline found
+
+if(empty($thisstoryline)){
+
+	echo '<div class="msg error f-c">' . $lang['No storyline was found with this information.'] . '</div>';
+
+}
+
+else{
+
+	
+
+	//delete the storyline if confirmed
+
+	if(getSlug(5) == "confirmed"){
+
+	
+
+		$stmt = $cc->prepare("SELECT * FROM cc_" . $tableprefix . "comics_storyline WHERE parent=:parent");
+
+		$stmt->execute(['parent' => $thisstoryline['id']]);
+
+		$children = $stmt->fetchAll();
+
+		
+
+		//move the children up a level
+
+		foreach($children as $child){
+
+			$stmt = $cc->prepare("UPDATE cc_" . $tableprefix . "comics_storyline SET parent=:parent AND level=:level WHERE id=:id");
+
+			$stmt->execute(['parent' => $thisstoryline['parent'], 'level' => $thisstoryline['level'], 'id' => $child['id']]);
+
+		}
+
+		
+
+		$stmt = $cc->prepare("DELETE FROM cc_" . $tableprefix . "comics_storyline WHERE id=:id");
+
+		$stmt->execute(['id' => $thisstoryline['id']]);
+
+		
+
+		//give success message
+
+		?>
+
+		<div class="msg success f-c"><?=str_replace("%s",$thisstoryline['name'],$lang['%s has been deleted.'])?></div>
+
+		
+
+		<?php
+
+		
+
+		
+
+	}else{
+
+	
+
+		//prompt user to delete page ?>
+
+
+
+		<div class="msg prompt f-c"><?=str_replace("%s",$thisstoryline['name'],$lang['Are you sure you want to delete %s? This action cannot be undone.'])?> <?=$lang['Sub-storylines will be moved up to this storyline\'s level.']?></div>
+
+		<?php
+
+
+
+		echo '<div class="cc-btn-row">';
+
+		buildButton(
+
+			"light-bg",
+
+			$ccurl . $navslug.'/'.$ccpage->module->slug.'/delete-storyline/' . $thisstoryline['id'] . '/confirmed',
+
+			$lang['Yes']
+
+		);
+
+		buildButton(
+
+			"dark-bg",
+
+			$ccurl . $navslug.'/'.$ccpage->module->slug."/manage-posts",
+
+			$lang['No']
+
+		);
+
+		echo '</div>';
+
+		
+
+	}
+
+
+
+}
+
+?>
+
+
+
 </main>


### PR DESCRIPTION
When deleting a storyline that's the parent to other storylines, everything bugs out because there are more parameters than there are placeholders in the query. This fixes that.

I have never used this website before so in case it isn't showing you what I did, the change is on line 95 and I added "AND level=:level" to the query.

I also don't know why it double spaced everything in case the person this was written for can still read this?? I didn't do that.

I did not mean to fork this and turn it into my own repository and I have no idea how to undo that, I just wanted to share this fix I made to my own copy of comic control today because I saw the bug still existed here.